### PR TITLE
Change DirectoryResource::getModificationTime to return the modified time of the directory itself

### DIFF
--- a/src/Lurker/Resource/DirectoryResource.php
+++ b/src/Lurker/Resource/DirectoryResource.php
@@ -25,48 +25,7 @@ class DirectoryResource extends BaseDirectoryResource implements ResourceInterfa
         clearstatcache(true, $resource);
         $newestMTime = filemtime($resource);
 
-        foreach ($this->getFilteredChilds() as $file) {
-            clearstatcache(true, (string) $file);
-            $newestMTime = max($file->getMTime(), $newestMTime);
-        }
-
         return $newestMTime;
-    }
-
-    /**
-     * Returns the list of filtered file and directory childs of directory resource.
-     *
-     * @return array An array of files
-     */
-    public function getFilteredChilds()
-    {
-        if (!$this->exists()) {
-            return array();
-        }
-
-        $resource = $this->getResource();
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($resource, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::SELF_FIRST
-        );
-
-        $childs = array();
-        foreach ($iterator as $file) {
-            // if regex filtering is enabled only return matching files
-            if ($file->isFile() && !$this->hasFile($file)) {
-                continue;
-            }
-
-            // always monitor directories for changes, except the .. entries
-            // (otherwise deleted files wouldn't get detected)
-            if ($file->isDir() && '/..' === substr($file, -3)) {
-                continue;
-            }
-
-            $childs[] = $file;
-        }
-
-        return $childs;
     }
 
     public function isFresh($timestamp)


### PR DESCRIPTION
Hello,

I've a question about `DirectoryResource::getModificationTime` implementation that have great impact on performance : 

I've noted that the modification time value of the DirectoryResource is impacted by the files contained in it (see [implementation](https://github.com/henrikbjorn/Lurker/blob/master/src/Lurker/Resource/DirectoryResource.php#L28-L31)). It seems it could be bypassed, using the directory _mtime_ (by removing the previously mentioned lines).
Doing this, I got performance x10 : scanning a folder containing 9300 files in 2400 folders take 0.8 second whereas it takes about 9 seconds with the current implementation.

The `DirectoryResource::getModificationTime` method is only used in [ResourceStateChecker::getChangeset](https://github.com/henrikbjorn/Lurker/blob/master/src/Lurker/StateChecker/ResourceStateChecker.php#L55-L92) to get time modification (useful in case of create / delete). 
For the modify event, it could be used (trigger a directory MODIFY event in case its content has changed) **but** it's discarded in the DirectoryStateChecker::getChangetSet (see [implementation](https://github.com/henrikbjorn/Lurker/blob/master/src/Lurker/StateChecker/NewDirectoryStateChecker.php#L35-L38))

So I would consider removing this, feedback appreciated.
