### PR TITLE
Fix warnings and exceptions that could be thrown in some race conditions

### DIFF
--- a/src/Lurker/Resource/FileResource.php
+++ b/src/Lurker/Resource/FileResource.php
@@ -15,11 +15,12 @@ class FileResource extends BaseFileResource implements ResourceInterface
             return -1;
         }
 
-        $resource = $this->getResource();
+        clearstatcache(true, $this->getResource());
+        if (false === $mtime = @filemtime($this->getResource())) {
+            return -1;
+        }
 
-        clearstatcache(true, $resource);
-
-        return filemtime($resource);
+        return $mtime;
     }
 
     public function getId()
@@ -38,7 +39,8 @@ class FileResource extends BaseFileResource implements ResourceInterface
 
     public function exists()
     {
+        clearstatcache(true, $this->getResource());
+
         return is_file($this);
     }
-
 }


### PR DESCRIPTION
When running Lurker on huge directories, and removing all files while lurker is processing, some warnings may occur due to some `filemtime` calls on removed file, an UnexpectedValueException may be thrown

This fix solves the Fatal "Unhandled exception" and the warnings.
