### PR TITLE
Add ResourceWatcherEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
   * Typo and examples fixes.
   * Change DirectoryResource::getModificationTime to return the modified time of the directory itself.
   * Fix warnings and exceptions that could be thrown in some race conditions.
+  * Add `Lurker\Event\ResourceWatcherEvent` for ResourceWatcher events.
 
 1.0.0 (2013-07-04)
 ------------------

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $watcher->addListener('twig.templates', function (FilesystemEvent $event) {
 $watcher->start();
 ```
 
-The above example would watch for all events `create`, `delete` and `modify`. This can be controlled by passing a 
+The above example would watch for all events `create`, `delete` and `modify`. This can be controlled by passing a
 third parameter to `track()`.
 
 ``` php
@@ -58,6 +58,20 @@ $watcher->track('twig.templates', '/path/to/views', FilesystemEvent::ALL);
 ```
 
 Note that `FilesystemEvent::ALL` is a special case and of course means it will watch for every type of event.
+
+### Resource Watcher events
+
+The resource watcher itslef triggers event on start, stop and period (the period
+duration is defined as the first argument of `ResourceWatcher::start` method).
+
+``` php
+<?php
+use Lurker\Event\ResourceWatcherEvent as Event;
+
+$watcher->getEventDispatcher()->addListener(Event::START, function (Event $event) { echo "resource watcher is starting\n"; });
+$watcher->getEventDispatcher()->addListener(Event::STOP, function (Event $event) { echo "resource watcher is stopping\n"; });
+$watcher->getEventDispatcher()->addListener(Event::PERIOD, function (Event $event) { echo "resource watcher has finished a period\n"; });
+```
 
 Special Thanks
 --------------

--- a/src/Lurker/Event/ResourceWatcherEvent.php
+++ b/src/Lurker/Event/ResourceWatcherEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Lurker\Event;
+
+use Lurker\ResourceWatcher;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * ResourceWatcher event.
+ */
+class ResourceWatcherEvent extends Event
+{
+    const START = 'resource_watcher.start';
+    const STOP = 'resource_watcher.stop';
+    const PERIOD = 'resource_watcher.period';
+
+    private $watcher;
+
+    /**
+     * Initializes the ResourceWatcher event
+     *
+     * @param ResourceWatcher $watcher
+     * @param string          $type
+     */
+    public function __construct(ResourceWatcher $watcher)
+    {
+        $this->watcher = $watcher;
+    }
+
+    /**
+     * Returns ResourceWatcher.
+     *
+     * @return ResourceWatcher
+     */
+    public function getResourceWatcher()
+    {
+        return $this->watcher;
+    }
+}

--- a/src/Lurker/ResourceWatcher.php
+++ b/src/Lurker/ResourceWatcher.php
@@ -3,6 +3,7 @@
 namespace Lurker;
 
 use Lurker\Event\FilesystemEvent;
+use Lurker\Event\ResourceWatcherEvent;
 use Lurker\Exception\InvalidArgumentException;
 use Lurker\Resource\DirectoryResource;
 use Lurker\Resource\FileResource;
@@ -156,6 +157,7 @@ class ResourceWatcher
     {
         $totalTime = 0;
         $this->watching = true;
+        $this->getEventDispatcher()->dispatch(ResourceWatcherEvent::START, new ResourceWatcherEvent($this));
 
         while ($this->watching) {
             usleep($checkInterval);
@@ -180,9 +182,10 @@ class ResourceWatcher
                     $event
                 );
             }
+            $this->getEventDispatcher()->dispatch(ResourceWatcherEvent::PERIOD, new ResourceWatcherEvent($this));
         }
 
-        $this->watching = false;
+        $this->stop();
     }
 
     /**
@@ -191,5 +194,6 @@ class ResourceWatcher
     public function stop()
     {
         $this->watching = false;
+        $this->getEventDispatcher()->dispatch(ResourceWatcherEvent::STOP, new ResourceWatcherEvent($this));
     }
 }

--- a/tests/Lurker/Tests/Event/ResourceWatcherEventTest.php
+++ b/tests/Lurker/Tests/Event/ResourceWatcherEventTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lurker\Tests\Event;
+
+use Lurker\Event\ResourceWatcherEvent;
+
+class ResourceWatcherEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructAndGetters()
+    {
+        $watcher = $this->getMockBuilder('Lurker\ResourceWatcher')
+            ->disableOriginalCOnstructor()
+            ->getMock();
+        $event = new ResourceWatcherEvent($watcher);
+
+        $this->assertSame($watcher, $event->getResourceWatcher());
+    }
+}


### PR DESCRIPTION
Hey,

this PR adds `ResourceWatcherEvent` providing three events type to interact with the ResourceWatcher itself.
It can be very convenient in some case to know when a period has been finished.

For example, if listening to the events in a directory : 
- I considering a created / modified file as "hot"
- I wait 10 seconds on a hot file to consider it "cold". If a modification occurs within the 10 seconds, it's still "hot". When it's "cold", I can process it safely (FTP files being written can take long time if the client disconnects then  resumes)
- Once the 10 seconds are over, I process it.

With the current implementation, if nothing changes in the directory, there are no events. We have to run `ResourceWatcher::start` with a time limit , then process files, then re-run etc...

With this PR, this kind of usecase is doable out of the box.
