### PR TITLE
Fix failing exception message test in ResourceWatcherTest

### DIFF
--- a/tests/Lurker/Tests/ResourceWatcherTest.php
+++ b/tests/Lurker/Tests/ResourceWatcherTest.php
@@ -199,6 +199,9 @@ class ResourceWatcherTest extends \PHPUnit_Framework_TestCase
         $watcher->start(1,1);
     }
 
+    /**
+     * @group medium
+     */
     public function testTrackingFunctionally()
     {
         $file  = tempnam(sys_get_temp_dir(), 'sf2_resource_watcher_');

--- a/tests/Lurker/Tests/Tracker/RecursiveIteratorTrackerTest.php
+++ b/tests/Lurker/Tests/Tracker/RecursiveIteratorTrackerTest.php
@@ -4,6 +4,9 @@ namespace Lurker\Tests\Tracker;
 
 use Lurker\Tracker\RecursiveIteratorTracker;
 
+/**
+ * @group medium
+ */
 class RecursiveIteratorTrackerTest extends TrackerTest
 {
     /**


### PR DESCRIPTION
Haven't been able to run the full test suite; can't run `inotify` on OS X! Hopefully Travis will run them on the PR.

M
