### PR TITLE
Resolve issues with Symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
 
     "require" : {
         "php"                      : ">=5.3.3",
-        "symfony/config"           : "^2.2|^3.0",
         "symfony/event-dispatcher" : "^2.2|^3.0"
     },
 

--- a/src/Lurker/Resource/DirectoryResource.php
+++ b/src/Lurker/Resource/DirectoryResource.php
@@ -2,13 +2,60 @@
 
 namespace Lurker\Resource;
 
-use Symfony\Component\Config\Resource\DirectoryResource as BaseDirectoryResource;
+use Lurker\Exception\InvalidArgumentException;
 
 /**
  * @package Lurker
  */
-class DirectoryResource extends BaseDirectoryResource implements ResourceInterface
+class DirectoryResource implements ResourceInterface
 {
+    /**
+     * @var string
+     */
+    private $resource;
+
+    /**
+     * @var string|null
+     */
+    private $pattern;
+
+    /**
+     * @param string $resource
+     * @param string|null $pattern
+     */
+    public function __construct($resource, $pattern = null)
+    {
+        $this->resource = realpath($resource);
+        $this->pattern = $pattern;
+
+        if (false === $this->resource || !is_dir($this->resource)) {
+            throw new InvalidArgumentException(sprintf('The directory "%s" does not exist.', $resource));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getResource()
+    {
+        return $this->resource;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPattern()
+    {
+        return $this->pattern;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return md5(serialize(array($this->resource, $this->pattern)));
+    }
 
     public function exists()
     {

--- a/src/Lurker/Resource/FileResource.php
+++ b/src/Lurker/Resource/FileResource.php
@@ -2,13 +2,50 @@
 
 namespace Lurker\Resource;
 
-use Symfony\Component\Config\Resource\FileResource as BaseFileResource;
+use Lurker\Exception\InvalidArgumentException;
 
 /**
  * @package Lurker
  */
-class FileResource extends BaseFileResource implements ResourceInterface
+class FileResource implements ResourceInterface
 {
+    /**
+     * @var string
+     */
+    private $resource;
+
+    /**
+     * @param string $resource
+     */
+    public function __construct($resource)
+    {
+        $this->resource = realpath($resource);
+
+        if (false === $this->resource && file_exists($resource)) {
+            $this->resource = $resource;
+        }
+
+        if (false === $this->resource) {
+            throw new InvalidArgumentException(sprintf('The file "%s" does not exist.', $resource));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getResource()
+    {
+        return $this->resource;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->resource;
+    }
+
     public function getModificationTime()
     {
         if (!$this->exists()) {

--- a/src/Lurker/Resource/ResourceInterface.php
+++ b/src/Lurker/Resource/ResourceInterface.php
@@ -2,12 +2,10 @@
 
 namespace Lurker\Resource;
 
-use Symfony\Component\Config\Resource\ResourceInterface as BaseResourceInterface;
-
 /**
  * @package Lurker
  */
-interface ResourceInterface extends BaseResourceInterface
+interface ResourceInterface
 {
     /**
      * @return boolean


### PR DESCRIPTION
This commit removes the dependency on the Symfony Config component. The
only code other than getters that was actually being used was the
constructors. In symfony 2, these were incredibly basic. In symfony 3,
they perform some validation.

This validation was causing a couple of "does not exist" tests to fail,
as the Symfony Config module was performing these checks before the
Lurker module, and throwing a different exception. Removing this
dependency neatly solves this issue at the same time.
