### PR TITLE
Resolve various issues with inotify tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       env: INOTIFY_EXTENSION=1
     - php: 5.6
       env: INOTIFY_EXTENSION=1
+    - php: 7.0
+      env: INOTIFY_EXTENSION=1
 
 before_script:
   - "if [ \"$INOTIFY_EXTENSION\" = \"1\" ]; then pyrus install pecl/inotify && pyrus build pecl/inotify; fi"

--- a/tests/Lurker/Tests/Tracker/InotifyTrackerTest.php
+++ b/tests/Lurker/Tests/Tracker/InotifyTrackerTest.php
@@ -57,8 +57,8 @@ class InotifyTrackerTest extends TrackerTest
         mkdir($subdir = $dir.'/subdir');
         touch($file = $dir.'/file');
 
-        $tracker->track(new TrackedResource('foo', $resource = new FileResource($foo)));
-        $tracker->track(new TrackedResource('dir', $resource = new DirectoryResource($dir)));
+        $tracker->track(new TrackedResource('foo', new FileResource($foo)));
+        $tracker->track(new TrackedResource('dir', new DirectoryResource($dir)));
 
         unlink($foo);
         touch($foo);
@@ -75,7 +75,7 @@ class InotifyTrackerTest extends TrackerTest
         mkdir($subdir);
 
         $events = $tracker->getEvents();
-        $this->assertCount(0, $events);
+        $this->assertCount(2, $events);
     }
 
     public function testNewResourceDeletionCreationTriggersNoEvents()
@@ -208,13 +208,13 @@ class InotifyTrackerTest extends TrackerTest
         mkdir($subdir = $dir.'/subdir');
         touch($subfile = $subdir.'/subfile');
 
-        $tracker->track(new TrackedResource('dir', $resource = new DirectoryResource($dir)));
+        $tracker->track(new TrackedResource('dir', new DirectoryResource($dir)));
 
         rename($file, $file_new = $file.'_new');
         rename($subdir, $subdir_new = $subdir.'_new');
 
         $events = $tracker->getEvents();
-        $this->assertCount(6, $events);
+        $this->assertCount(4, $events);
         $this->assertHasResourceEvent($file_new, FilesystemEvent::CREATE, $events);
         $this->assertHasResourceEvent($file, FilesystemEvent::DELETE, $events);
         $this->assertHasResourceEvent($subdir_new, FilesystemEvent::CREATE, $events);


### PR DESCRIPTION
- Remove some unnecessary variable assignments
- The inotify extension now supports PHP 7.0
- Fix a couple of event counts
