### PR TITLE
Allow Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 sudo: false
 
-
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -12,6 +11,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 
 matrix:
@@ -27,3 +28,6 @@ before_script:
   - "if [ \"$INOTIFY_EXTENSION\" = \"1\" ]; then pyrus install pecl/inotify && pyrus build pecl/inotify; fi"
   - "if [ \"$INOTIFY_EXTENSION\" = \"1\" ]; then echo \"extension=inotify.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - "composer install --no-progress"
+
+script:
+  - "vendor/bin/phpunit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,11 @@ php:
 
 matrix:
   include:
-    - php: 5.4
-      env: INOTIFY_EXTENSION=1
-    - php: 5.5
-      env: INOTIFY_EXTENSION=1
     - php: 5.6
       env: INOTIFY_EXTENSION=1
 
 before_script:
-  - "if [ \"$INOTIFY_EXTENSION\" = \"1\" ]; then pyrus install pecl/inotify && pyrus build pecl/inotify; fi"
-  - "if [ \"$INOTIFY_EXTENSION\" = \"1\" ]; then echo \"extension=inotify.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
+  - "if [ \"$INOTIFY_EXTENSION\" = \"1\" ]; then pecl install inotify-0.1.6; fi"
   - "composer install --no-progress"
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
 
     "require" : {
         "php"                      : ">=5.3.3",
-        "symfony/config"           : "^2.2|^3.0",
-        "symfony/event-dispatcher" : "^2.2|^3.0"
+        "symfony/config"           : "^2.2 || ^3.0 || ^4.0",
+        "symfony/event-dispatcher" : "^2.2 || ^3.0 || ^4.0"
     },
 
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
         "branch-alias" : {
             "dev-master" : "1.0.x-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.0 || ^5.0"
     }
 }

--- a/tests/Lurker/Tests/Tracker/TrackerTest.php
+++ b/tests/Lurker/Tests/Tracker/TrackerTest.php
@@ -30,17 +30,16 @@ abstract class TrackerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Lurker\Exception\InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testDoesNotTrackMissingFiles()
     {
         $tracker = $this->getTracker();
-
-        $tracker->track(new TrackedResource('missing', new FileResource(__DIR__.'/missingfile')));
+        $tracker->track(new TrackedResource('missing', new FileResource(__DIR__ . '/missingfile')));
     }
 
     /**
-     * @expectedException Lurker\Exception\InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testDoesNotTrackMissingDirectories()
     {


### PR DESCRIPTION
Allowed Symfony 4, had to:

- Switch to composer install of PHPUnit, to only allow compatible versions
- Modify some tests due to break in Symfony 3.1
- Modify the way inotify is installed in Travis (old method no longer worked)

There are still inotify failures, I suspect related to more breaking changes in Symfony/FileResource, but I don't have time to reproduce locally right now; perhaps someone else can pick this up